### PR TITLE
Fix: bugfix: options object was changed when fed into constructor

### DIFF
--- a/src/lib/AMCPConnectionOptions.ts
+++ b/src/lib/AMCPConnectionOptions.ts
@@ -80,19 +80,22 @@ export class ConnectionOptions implements IConnectionOptions {
   constructor (options?: IConnectionOptions);
   constructor (hostOrOptions?: IConnectionOptions|string, port?: number) {
     // if object
-    let hasSetHostAndPort: boolean = false
+    let hasSetHostOrPort: boolean = false
     if (hostOrOptions && typeof hostOrOptions === 'object') {
       if (hostOrOptions.hasOwnProperty('host') && hostOrOptions.host !== undefined) {
         let host: string = hostOrOptions!.host!
         let dnsValidation: Array<string> | null = /((?=.{1,255}$)[0-9A-Za-z](?:(?:[0-9A-Za-z]|-){0,61}[0-9A-Za-z])?(?:\.[0-9A-Za-z](?:(?:[0-9A-Za-z]|-){0,61}[0-9A-Za-z])?)*\.?)(?:\:([0-9]{4}))?/.exec(host)
         if (dnsValidation) {
-          hasSetHostAndPort = true
-					// host
+          // host
           if (dnsValidation[1]) {
+            // port gets set directly, and we need to ignore it in the loop setting all other options
+            hasSetHostOrPort = true
             this.host = dnsValidation[1]
           }
 					// port
           if (dnsValidation[2]) {
+            // port gets set directly, and we need to ignore it in the loop setting all other options
+            hasSetHostOrPort = true
             this.port = parseInt(dnsValidation[2], 10)
           }
         }
@@ -100,7 +103,10 @@ export class ConnectionOptions implements IConnectionOptions {
 
 			// @todo: object assign
       for (let key in hostOrOptions) {
-        if (hasSetHostAndPort && (key === 'host' || key === 'port')) continue
+        // host or port has been set directly and should not be overridden again
+        if (hasSetHostOrPort && (key === 'host' || key === 'port')) {
+          continue
+        }
         if (!hostOrOptions.hasOwnProperty(key)) {
           continue
         }

--- a/src/lib/AMCPConnectionOptions.ts
+++ b/src/lib/AMCPConnectionOptions.ts
@@ -79,13 +79,14 @@ export class ConnectionOptions implements IConnectionOptions {
   constructor (host?: string, port?: number);
   constructor (options?: IConnectionOptions);
   constructor (hostOrOptions?: IConnectionOptions|string, port?: number) {
-		// if object
+    // if object
+    let hasSetHostAndPort: boolean = false
     if (hostOrOptions && typeof hostOrOptions === 'object') {
       if (hostOrOptions.hasOwnProperty('host') && hostOrOptions.host !== undefined) {
         let host: string = hostOrOptions!.host!
         let dnsValidation: Array<string> | null = /((?=.{1,255}$)[0-9A-Za-z](?:(?:[0-9A-Za-z]|-){0,61}[0-9A-Za-z])?(?:\.[0-9A-Za-z](?:(?:[0-9A-Za-z]|-){0,61}[0-9A-Za-z])?)*\.?)(?:\:([0-9]{4}))?/.exec(host)
         if (dnsValidation) {
-          delete hostOrOptions['host']
+          hasSetHostAndPort = true
 					// host
           if (dnsValidation[1]) {
             this.host = dnsValidation[1]
@@ -99,6 +100,7 @@ export class ConnectionOptions implements IConnectionOptions {
 
 			// @todo: object assign
       for (let key in hostOrOptions) {
+        if (hasSetHostAndPort && (key === 'host' || key === 'port')) continue
         if (!hostOrOptions.hasOwnProperty(key)) {
           continue
         }


### PR DESCRIPTION
This PR should fix this:
let options = {host: '192.168.0.1', autoConnect: false}
let c0 = new CasparCG(options)
let c1 = new CasparCG(options)

console.log(c0.host) // outputs '192.168.0.1'
console.log(c1.host) // outputs 'localhost', should be '192.168.0.1'