### PR TITLE
Implement Swap command

### DIFF
--- a/src/CasparCG.ts
+++ b/src/CasparCG.ts
@@ -166,7 +166,8 @@ export interface IMixer {
 export interface IChannel {
   clear (channel: number, layer?: number): Promise<IAMCPCommand>
 		//// call(channel: number, layer: number): Promise<IAMCPCommand>;
-		//// swap(): Promise<IAMCPCommand>;
+  swapChannels (channel1: number, channel2?: number, transformations?: boolean): Promise<IAMCPCommand>
+  swapLayers (channel1: number, layer1?: number, channel2?: number, layer2?: number, transformations?: boolean): Promise<IAMCPCommand>
 		//// add(channel: number): Promise<IAMCPCommand>;
   print (channel: number): Promise<IAMCPCommand>
 		//// set(channel: number): Promise<IAMCPCommand>;
@@ -1515,12 +1516,17 @@ export class CasparCG extends EventEmitter implements ICasparCGConnection, Conne
   }
 
 	/**
-	 * @todo	implement
-	 * @todo	document
+	 * <https://github.com/CasparCG/help/wiki/AMCP-Protocol#swap>
 	 */
-  public swap (): Promise<IAMCPCommand> {
-		// @todo: overloading of origin/destination pairs
-    return this.do(new AMCP.SwapCommand())
+  public swapLayers (channel1: number, layer1: number, channel2: number, layer2: number, transformations?: boolean): Promise<IAMCPCommand> {
+    return this.do(new AMCP.SwapCommand({address1: channel1 + '-' + layer1, address2: channel2 + '-' + layer2, transformations: transformations}))
+  }
+
+	/**
+	 * <https://github.com/CasparCG/help/wiki/AMCP-Protocol#swap>
+	 */
+  public swapChannels (channel1: number, channel2: number, transformations?: boolean): Promise<IAMCPCommand> {
+    return this.do(new AMCP.SwapCommand({address1: channel1, address2: channel2, transformations: transformations}))
   }
 
 	/**

--- a/src/lib/AMCP.ts
+++ b/src/lib/AMCP.ts
@@ -1394,18 +1394,16 @@ export class CallCommand extends AbstractLayerWithFallbackCommand {
 	/**
 	 *
 	 */
-export class SwapCommand extends AbstractChannelOrLayerCommand {
+export class SwapCommand extends AbstractCommand {
   static readonly commandString = 'SWAP'
+  static readonly protocolLogic = [
 
-		/**
-		 *
-		 */
-  constructor () {
-    super('1-1') // @todo: foo
-			// @todo: custom parameters dual layerOrchannel with 1 optional param
-			// overloading in method
-  }
-
+  ]
+  paramProtocol = [
+    new ParamSignature(required, 'address1', null, new ParameterValidator.AddressValidator()),
+    new ParamSignature(required, 'address2', null, new ParameterValidator.AddressValidator()),
+    new ParamSignature(optional, 'auto', null, new ParameterValidator.BooleanValidatorWithDefaults('TRANSFORMS'))
+  ]
 }
 
 	/**

--- a/src/lib/ParamValidators.ts
+++ b/src/lib/ParamValidators.ts
@@ -547,17 +547,12 @@ export class TimecodeValidator extends StringValidator {
 }
 
 export class AddressValidator extends AbstractValidator {
-  resolve (data: Object) : ParamData {
+  resolve (data: Object): ParamData {
     if (!data) return false
     let address: string = data.toString()
     const match = address.match(/^([0-9]{1,4})(?:-([0-9]{1,4}))?$/)
     if (!match || Number(match[1]) > 9999 || (typeof match[2] !== 'undefined' && Number (match[2]) > 9999)) return false
     return address
-  }
-
-  isChannel ()
-  {
-
   }
 }
 

--- a/src/lib/ParamValidators.ts
+++ b/src/lib/ParamValidators.ts
@@ -545,6 +545,22 @@ export class TemplateDataValidator extends AbstractValidator {
 export class TimecodeValidator extends StringValidator {
   // nothing
 }
+
+export class AddressValidator extends AbstractValidator {
+  resolve (data: Object) : ParamData {
+    if (!data) return false
+    let address: string = data.toString()
+    const match = address.match(/^([0-9]{1,4})(?:-([0-9]{1,4}))?$/)
+    if (!match || Number(match[1]) > 9999 || (typeof match[2] !== 'undefined' && Number (match[2]) > 9999)) return false
+    return address
+  }
+
+  isChannel ()
+  {
+
+  }
+}
+
 export class CommandValidator extends AbstractValidator {
   resolve (command: Object): ParamData {
     if (CommandNS.isIAMCPCommand(command)) {


### PR DESCRIPTION
Hi,

I needed the swap command so I implemented it.

First i tried to make a method like this : 

```
swap (channel1: number, channel2: number, transformations?: boolean),
swap (channel1: number, layer1: number, channel2: number, layer2:number, transformations?: boolean) {
...
}
```

But it doesn't work, i'm lacking Typescript knowledge to know why.

So I made 2 methods : `swapChannels` and `swapLayers`

In the command implementation i made two params : address1 and address2, with an address validator that check if parameters are like '1-1' (layer) or 1 (channel). But I didn't find a way to check if both address1 and address2 are of the same type : layer or channel

This PR is just a proposal, if you don't like it i would understand.