### PR TITLE
 fix: use 'new' keyword

### DIFF
--- a/src/CasparCG.ts
+++ b/src/CasparCG.ts
@@ -694,10 +694,8 @@ export class CasparCG extends EventEmitter implements ICasparCGConnection, Conne
 				if (AMCP.hasOwnProperty(commandOrString)) {
 					// @todo: parse out params from commandString, if Params is empty and commandString.split(" ").length > 1
 					// @todo: typechecking with fallback
-					command = Object.create((AMCP as any)[commandOrString]['prototype'])
-					// @todo: typechecking with fallback
-					if (command) {
-						command.constructor.apply(command, params)
+					if ((AMCP as any)[commandOrString]) {
+						command = new (AMCP as any)(commandOrString)(params)
 					} else {
 						throw new Error('Invalid command constructor')
 					}

--- a/src/lib/AMCP.ts
+++ b/src/lib/AMCP.ts
@@ -1891,8 +1891,9 @@ export namespace AMCPUtil {
 		// errror: commandstatus -1 //invalid command
 
 		// @todo: error handling much?????? (callback??????)
-		let command: IAMCPCommand = Object.create((AMCP as any)[cmd._commandName]['prototype'])
-		command.constructor.call(command, cmd._objectParams)
+		// let command: IAMCPCommand = Object.create((AMCP as any)[cmd._commandName]['prototype'])
+		// command.constructor.call(command, cmd._objectParams)
+		let command: IAMCPCommand = new (AMCP as any)[cmd._commandName](cmd._objectParams)
 		command.populate(cmd, id)
 		return command
 	}

--- a/src/lib/AbstractCommand.ts
+++ b/src/lib/AbstractCommand.ts
@@ -233,7 +233,7 @@ export namespace Command {
 			// data is valid
 			let validData: Object = {}
 			if (this.responseProtocol.validator) { // @todo: typechecking ("class that implements....")
-				let validator: IResponseValidator = Object.create(this.responseProtocol.validator['prototype'])
+				const validator: IResponseValidator = new this.responseProtocol.validator()
 				validData = validator.resolve(response)
 				if (validData === false) {
 					return false
@@ -242,7 +242,7 @@ export namespace Command {
 
 			// data gets parsed
 			if (this.responseProtocol.parser && validData) { // @todo: typechecking ("class that implements....")
-				let parser: IResponseParser = Object.create(this.responseProtocol.parser['prototype'])
+				const parser: IResponseParser = new this.responseProtocol.parser()
 				parser.context = this.context
 				validData = parser.parse(validData)
 				if (validData === false) {

--- a/src/lib/Config.ts
+++ b/src/lib/Config.ts
@@ -1382,8 +1382,7 @@ export namespace Config {
 					}
 				}
 				if (namespace && namespace.hasOwnProperty(memberName)) {
-					let member: v2xx.Consumer = Object.create(namespace[memberName]['prototype'])
-					member.constructor.call(member)
+					let member: v2xx.Consumer = new namespace[memberName]()
 					this.importAllValues(root, member)
 				}
 			}


### PR DESCRIPTION
Fixes some a type error in a dependant project:

`TypeError: Class constructors cannot be invoked without 'new'`