### PR TITLE
Feature/command promise fallback

### DIFF
--- a/src/CasparCG.ts
+++ b/src/CasparCG.ts
@@ -646,12 +646,12 @@ export class CasparCG extends EventEmitter implements ICasparCGConnection, Conne
 	 */
 	public do(command: IAMCPCommand): Promise<IAMCPCommand>
 	public do(commandString: string, ...params: (string | Param)[]): Promise<IAMCPCommand>
-	public do(commandOrString: (IAMCPCommand | string), ...params: (string | Param)[]): Promise<IAMCPCommand> | undefined {
+	public do(commandOrString: (IAMCPCommand | string), ...params: (string | Param)[]): Promise<IAMCPCommand | void> {
 		let command: IAMCPCommand | undefined = this.createCommand(commandOrString, ...params)
 		if (command) {
 			return this.queueCommand(command)
 		}
-		return
+		return Promise.resolve()
 	}
 
 	/**
@@ -660,12 +660,12 @@ export class CasparCG extends EventEmitter implements ICasparCGConnection, Conne
 	 */
 	public doNow(command: IAMCPCommand): Promise<IAMCPCommand>
 	public doNow(commandString: string, ...params: (string | Param)[]): Promise<IAMCPCommand>
-	public doNow(commandOrString: (IAMCPCommand | string), ...params: (string | Param)[]): Promise<IAMCPCommand> | undefined {
+	public doNow(commandOrString: (IAMCPCommand | string), ...params: (string | Param)[]): Promise<IAMCPCommand | void> {
 		let command: IAMCPCommand | undefined = this.createCommand(commandOrString, ...params)
 		if (command) {
 			return this.queueCommand(command, Priority.HIGH)
 		}
-		return
+		return Promise.resolve()
 	}
 
 	/**
@@ -674,12 +674,12 @@ export class CasparCG extends EventEmitter implements ICasparCGConnection, Conne
 	 */
 	public doLater(command: IAMCPCommand): Promise<IAMCPCommand>
 	public doLater(commandString: string, ...params: (string | Param)[]): Promise<IAMCPCommand>
-	public doLater(commandOrString: (IAMCPCommand | string), ...params: (string | Param)[]): Promise<IAMCPCommand> | undefined {
+	public doLater(commandOrString: (IAMCPCommand | string), ...params: (string | Param)[]): Promise<IAMCPCommand | void> {
 		let command: IAMCPCommand | undefined = this.createCommand(commandOrString, ...params)
 		if (command) {
 			return this.queueCommand(command, Priority.LOW)
 		}
-		return
+		return Promise.resolve()
 	}
 
 	/**

--- a/src/CasparCG.ts
+++ b/src/CasparCG.ts
@@ -262,12 +262,12 @@ export interface ICasparCGConnection {
 	createCommand(command: IAMCPCommand): IAMCPCommand | undefined
 	createCommand(commandString: string, ...params: (string | Param)[]): IAMCPCommand | undefined
 	queueCommand(command: IAMCPCommand, priority: Priority): Promise<IAMCPCommand>
-	do(command: IAMCPCommand): Promise<IAMCPCommand>
-	do(commandString: string, ...params: (string | Param)[]): Promise<IAMCPCommand>
-	doNow(command: IAMCPCommand): Promise<IAMCPCommand>
-	doNow(commandString: string, ...params: (string | Param)[]): Promise<IAMCPCommand>
-	doLater(command: IAMCPCommand): Promise<IAMCPCommand>
-	doLater(commandString: string, ...params: (string | Param)[]): Promise<IAMCPCommand>
+	do(command: IAMCPCommand): Promise<IAMCPCommand | void>
+	do(commandString: string, ...params: (string | Param)[]): Promise<IAMCPCommand | void>
+	doNow(command: IAMCPCommand): Promise<IAMCPCommand | void>
+	doNow(commandString: string, ...params: (string | Param)[]): Promise<IAMCPCommand | void>
+	doLater(command: IAMCPCommand): Promise<IAMCPCommand | void>
+	doLater(commandString: string, ...params: (string | Param)[]): Promise<IAMCPCommand | void>
 }
 
 /**

--- a/src/CasparCG.ts
+++ b/src/CasparCG.ts
@@ -70,9 +70,9 @@ export namespace CasparCGProtocols {
 			loadDecklink(channel: number, layer: number, device: number, transition?: Enum.Transition | string, transitionDurationOrMaskFile?: number | string, transitionEasingOrStingDuration?: Enum.Ease | string | number, transitionDirectionOrOverlay?: Enum.Direction | string, length?: number, filter?: string, format?: Enum.ChannelFormat | string, channelLayout?: Enum.ChannelLayout | string): Promise<IAMCPCommand>
 			playDecklink(channel: number, layer?: number, device?: number, transition?: Enum.Transition | string, transitionDurationOrMaskFile?: number | string, transitionEasingOrStingDuration?: Enum.Ease | string | number, transitionDirectionOrOverlay?: Enum.Direction | string, length?: number, filter?: string, format?: Enum.ChannelFormat | string, channelLayout?: Enum.ChannelLayout | string): Promise<IAMCPCommand>
 			loadHtmlPageBg(channel: number, layer: number, url: string, transition?: Enum.Transition | string, transitionDurationOrMaskFile?: number | string, transitionEasingOrStingDuration?: Enum.Ease | string | number, transitionDirectionOrOverlay?: Enum.Direction | string, seek?: number, length?: number, filter?: string, auto?: boolean | number | string): Promise<IAMCPCommand>
-			loadHtmlPageBgAuto(channel: number, layer: number, url: string, transition?: Enum.Transition | string, transitionDurationOrMaskFile?: number | string, transitionEasingOrStingDuration?: Enum.Ease | string | number, transitionDirectionOrOverlay?: Enum.Direction | string,): Promise<IAMCPCommand>
-			loadHtmlPage(channel: number, layer: number, url: string, transition?: Enum.Transition | string, transitionDurationOrMaskFile?: number | string, transitionEasingOrStingDuration?: Enum.Ease | string | number, transitionDirectionOrOverlay?: Enum.Direction | string,): Promise<IAMCPCommand>
-			playHtmlPage(channel: number, layer?: number, url?: string, transition?: Enum.Transition | string, transitionDurationOrMaskFile?: number | string, transitionEasingOrStingDuration?: Enum.Ease | string | number, transitionDirectionOrOverlay?: Enum.Direction | string,): Promise<IAMCPCommand>
+			loadHtmlPageBgAuto(channel: number, layer: number, url: string, transition?: Enum.Transition | string, transitionDurationOrMaskFile?: number | string, transitionEasingOrStingDuration?: Enum.Ease | string | number, transitionDirectionOrOverlay?: Enum.Direction | string): Promise<IAMCPCommand>
+			loadHtmlPage(channel: number, layer: number, url: string, transition?: Enum.Transition | string, transitionDurationOrMaskFile?: number | string, transitionEasingOrStingDuration?: Enum.Ease | string | number, transitionDirectionOrOverlay?: Enum.Direction | string): Promise<IAMCPCommand>
+			playHtmlPage(channel: number, layer?: number, url?: string, transition?: Enum.Transition | string, transitionDurationOrMaskFile?: number | string, transitionEasingOrStingDuration?: Enum.Ease | string | number, transitionDirectionOrOverlay?: Enum.Direction | string): Promise<IAMCPCommand>
 		}
 
 		/**
@@ -927,14 +927,14 @@ export class CasparCG extends EventEmitter implements ICasparCGConnection, Conne
 	/**
 	 *
 	 */
-	public loadHtmlPageBgAuto(channel: number, layer: number = NaN, url: string, transition?: Enum.Transition | string, transitionDurationOrMaskFile?: number | string, transitionEasingOrStingDuration?: Enum.Ease | string | number, transitionDirectionOrOverlay?: Enum.Direction | string,): Promise<IAMCPCommand> {
+	public loadHtmlPageBgAuto(channel: number, layer: number = NaN, url: string, transition?: Enum.Transition | string, transitionDurationOrMaskFile?: number | string, transitionEasingOrStingDuration?: Enum.Ease | string | number, transitionDirectionOrOverlay?: Enum.Direction | string): Promise<IAMCPCommand> {
 		return this.do(new AMCP.LoadHtmlPageBgCommand({ channel: channel, layer: layer, url: url, transition: transition, ...this._createTransitionOptionsObject(transition, transitionDurationOrMaskFile, transitionEasingOrStingDuration, transitionDirectionOrOverlay), auto: true }))
 	}
 
 	/**
 	 * <http://casparcg.com/wiki/CasparCG_2.1_AMCP_Protocol#LOAD>
 	 */
-	public loadHtmlPage(channel: number, layer: number = NaN, url: string, transition?: Enum.Transition | string, transitionDurationOrMaskFile?: number | string, transitionEasingOrStingDuration?: Enum.Ease | string | number, transitionDirectionOrOverlay?: Enum.Direction | string,): Promise<IAMCPCommand> {
+	public loadHtmlPage(channel: number, layer: number = NaN, url: string, transition?: Enum.Transition | string, transitionDurationOrMaskFile?: number | string, transitionEasingOrStingDuration?: Enum.Ease | string | number, transitionDirectionOrOverlay?: Enum.Direction | string): Promise<IAMCPCommand> {
 		return this.do(new AMCP.LoadHtmlPageCommand({ channel: channel, layer: layer, url: url, transition: transition, ...this._createTransitionOptionsObject(transition, transitionDurationOrMaskFile, transitionEasingOrStingDuration, transitionDirectionOrOverlay) }))
 	}
 
@@ -942,7 +942,7 @@ export class CasparCG extends EventEmitter implements ICasparCGConnection, Conne
 	 * <http://casparcg.com/wiki/CasparCG_2.1_AMCP_Protocol#PLAY>
 	 */
 	public playHtmlPage(channel: number, layer?: number): Promise<IAMCPCommand>
-	public playHtmlPage(channel: number, layer: number = NaN, url?: string, transition?: Enum.Transition | string, transitionDurationOrMaskFile?: number | string, transitionEasingOrStingDuration?: Enum.Ease | string | number, transitionDirectionOrOverlay?: Enum.Direction | string,): Promise<IAMCPCommand> {
+	public playHtmlPage(channel: number, layer: number = NaN, url?: string, transition?: Enum.Transition | string, transitionDurationOrMaskFile?: number | string, transitionEasingOrStingDuration?: Enum.Ease | string | number, transitionDirectionOrOverlay?: Enum.Direction | string): Promise<IAMCPCommand> {
 		return this.do(new AMCP.PlayHtmlPageCommand({ channel: channel, layer: layer, url: url, transition: transition, ...this._createTransitionOptionsObject(transition, transitionDurationOrMaskFile, transitionEasingOrStingDuration, transitionDirectionOrOverlay) }))
 	}
 

--- a/src/CasparCG.ts
+++ b/src/CasparCG.ts
@@ -262,12 +262,12 @@ export interface ICasparCGConnection {
 	createCommand(command: IAMCPCommand): IAMCPCommand | undefined
 	createCommand(commandString: string, ...params: (string | Param)[]): IAMCPCommand | undefined
 	queueCommand(command: IAMCPCommand, priority: Priority): Promise<IAMCPCommand>
-	do(command: IAMCPCommand): Promise<IAMCPCommand | void>
-	do(commandString: string, ...params: (string | Param)[]): Promise<IAMCPCommand | void>
-	doNow(command: IAMCPCommand): Promise<IAMCPCommand | void>
-	doNow(commandString: string, ...params: (string | Param)[]): Promise<IAMCPCommand | void>
-	doLater(command: IAMCPCommand): Promise<IAMCPCommand | void>
-	doLater(commandString: string, ...params: (string | Param)[]): Promise<IAMCPCommand | void>
+	do(command: IAMCPCommand): Promise<IAMCPCommand>
+	do(commandString: string, ...params: (string | Param)[]): Promise<IAMCPCommand>
+	doNow(command: IAMCPCommand): Promise<IAMCPCommand>
+	doNow(commandString: string, ...params: (string | Param)[]): Promise<IAMCPCommand>
+	doLater(command: IAMCPCommand): Promise<IAMCPCommand>
+	doLater(commandString: string, ...params: (string | Param)[]): Promise<IAMCPCommand>
 }
 
 /**
@@ -646,12 +646,12 @@ export class CasparCG extends EventEmitter implements ICasparCGConnection, Conne
 	 */
 	public do(command: IAMCPCommand): Promise<IAMCPCommand>
 	public do(commandString: string, ...params: (string | Param)[]): Promise<IAMCPCommand>
-	public do(commandOrString: (IAMCPCommand | string), ...params: (string | Param)[]): Promise<IAMCPCommand | void> {
+	public do(commandOrString: (IAMCPCommand | string), ...params: (string | Param)[]): Promise<IAMCPCommand> {
 		let command: IAMCPCommand | undefined = this.createCommand(commandOrString, ...params)
 		if (command) {
 			return this.queueCommand(command)
 		}
-		return Promise.resolve()
+		return Promise.reject()
 	}
 
 	/**
@@ -660,12 +660,12 @@ export class CasparCG extends EventEmitter implements ICasparCGConnection, Conne
 	 */
 	public doNow(command: IAMCPCommand): Promise<IAMCPCommand>
 	public doNow(commandString: string, ...params: (string | Param)[]): Promise<IAMCPCommand>
-	public doNow(commandOrString: (IAMCPCommand | string), ...params: (string | Param)[]): Promise<IAMCPCommand | void> {
+	public doNow(commandOrString: (IAMCPCommand | string), ...params: (string | Param)[]): Promise<IAMCPCommand> {
 		let command: IAMCPCommand | undefined = this.createCommand(commandOrString, ...params)
 		if (command) {
 			return this.queueCommand(command, Priority.HIGH)
 		}
-		return Promise.resolve()
+		return Promise.reject()
 	}
 
 	/**
@@ -674,12 +674,12 @@ export class CasparCG extends EventEmitter implements ICasparCGConnection, Conne
 	 */
 	public doLater(command: IAMCPCommand): Promise<IAMCPCommand>
 	public doLater(commandString: string, ...params: (string | Param)[]): Promise<IAMCPCommand>
-	public doLater(commandOrString: (IAMCPCommand | string), ...params: (string | Param)[]): Promise<IAMCPCommand | void> {
+	public doLater(commandOrString: (IAMCPCommand | string), ...params: (string | Param)[]): Promise<IAMCPCommand> {
 		let command: IAMCPCommand | undefined = this.createCommand(commandOrString, ...params)
 		if (command) {
 			return this.queueCommand(command, Priority.LOW)
 		}
-		return Promise.resolve()
+		return Promise.reject()
 	}
 
 	/**


### PR DESCRIPTION
* **What kind of change does this PR introduce?** 
Better API, prevents bugs. A couple of the central methods (do, doNow, doLater) could return both promises and void/undefined. In a promise chain, this breaks things, and will require all consumers downstream to handle the undefined case. 


* **What is the current behavior?** 
With the typings for the overloads not specifically type `| undefined` as an option, the first two method signatures falsely states that a promise will be returned at all times.



* **What is the new behavior (if this is a feature change)?**
Instead of correcting the typing information to ensure all consumers take into account the undefined case, we guarantee to return a promise at all times, even though it is an empty one. I haven't looked into if we have internal code expecting the promise to return an actual command, but the typings don't complain, so let's take the chance?

* **Other information**: