### PR TITLE
Adding support for subFolder argument in thumbnailList

### DIFF
--- a/src/CasparCG.ts
+++ b/src/CasparCG.ts
@@ -191,7 +191,7 @@ export namespace CasparCGProtocols {
 		 * AMCP Thumbnail-commands
 		 */
 		export interface IThumbnail {
-			thumbnailList(): Promise<IAMCPCommand>
+			thumbnailList(subFolder: string): Promise<IAMCPCommand>
 			thumbnailRetrieve(fileName: string): Promise<IAMCPCommand>
 			thumbnailGenerate(fileName: string): Promise<IAMCPCommand>
 			thumbnailGenerateAll(): Promise<IAMCPCommand>
@@ -1664,7 +1664,7 @@ export class CasparCG extends EventEmitter implements ICasparCGConnection, Conne
 	/**
 	 * <http://casparcg.com/wiki/CasparCG_2.1_AMCP_Protocol#THUMBNAIL_LIST>
 	 */
-	public thumbnailList(): Promise<IAMCPCommand> {
+	public thumbnailList(subFolder: string): Promise<IAMCPCommand> {
 		return this.do(new AMCP.ThumbnailListCommand())
 	}
 

--- a/src/CasparCG.ts
+++ b/src/CasparCG.ts
@@ -1665,7 +1665,7 @@ export class CasparCG extends EventEmitter implements ICasparCGConnection, Conne
 	 * <http://casparcg.com/wiki/CasparCG_2.1_AMCP_Protocol#THUMBNAIL_LIST>
 	 */
 	public thumbnailList(subFolder: string): Promise<IAMCPCommand> {
-		return this.do(new AMCP.ThumbnailListCommand())
+		return this.do(new AMCP.ThumbnailListCommand({ subFolder: subFolder}))
 	}
 
 	/**

--- a/src/lib/AMCP.ts
+++ b/src/lib/AMCP.ts
@@ -1691,7 +1691,9 @@ export namespace AMCP {
 	 */
 	export class ThumbnailListCommand extends AbstractCommand {
 		static readonly commandString = 'THUMBNAIL LIST'
-		// responseProtocol = new ResponseSignature(200, ResponseValidator.ListValidator, ResponseParser.ThumbnailListParser);
+		paramProtocol = [
+			new ParamSignature(optional, 'subFolder', null, new ParameterValidator.ClipNameValidator())
+		]
 		responseProtocol = new ResponseSignature(200, ResponseValidator.ListValidator, ResponseParser.ThumbnailListParser)
 	}
 


### PR DESCRIPTION
**What kind of change does this PR introduce?
The AMCP protocol can take an optional "subFolder" when calling THUMBNAIL LIST

This is added as an optional argument in casparcg-connection

before:
thumnailList()
after:
thumbnailList(optional: subfolder)