### PR TITLE
Added subFolder support for CLS and TLS commands

### DIFF
--- a/src/CasparCG.ts
+++ b/src/CasparCG.ts
@@ -202,9 +202,9 @@ export namespace CasparCGProtocols {
 		 */
 		export interface IQuery {
 			cinf(fileName: string): Promise<IAMCPCommand>
-			cls(): Promise<IAMCPCommand>
+			cls(subFolder?: string): Promise<IAMCPCommand>
 			fls(): Promise<IAMCPCommand>
-			tls(): Promise<IAMCPCommand>
+			tls(subFolder?: string): Promise<IAMCPCommand>
 			version(component?: Enum.Version): Promise<IAMCPCommand>
 			info(channel?: number, layer?: number): Promise<IAMCPCommand>
 			infoTemplate(template: string): Promise<IAMCPCommand>
@@ -1715,8 +1715,8 @@ export class CasparCG extends EventEmitter implements ICasparCGConnection, Conne
 	/**
 	 * <https://github.com/CasparCG/help/wiki/AMCP-Protocol#CLS>
 	 */
-	public cls(): Promise<IAMCPCommand> {
-		return this.do(new AMCP.ClsCommand())
+	public cls(subFolder?: string): Promise<IAMCPCommand> {
+		return this.do(new AMCP.ClsCommand({ subFolder: subFolder}))
 	}
 
 	/**
@@ -1729,8 +1729,8 @@ export class CasparCG extends EventEmitter implements ICasparCGConnection, Conne
 	/**
 	 * <https://github.com/CasparCG/help/wiki/AMCP-Protocol#TLS>
 	 */
-	public tls(): Promise<IAMCPCommand> {
-		return this.do(new AMCP.TlsCommand())
+	public tls(subFolder?: string): Promise<IAMCPCommand> {
+		return this.do(new AMCP.TlsCommand({ subFolder: subFolder}))
 	}
 
 	/**

--- a/src/lib/AMCP.ts
+++ b/src/lib/AMCP.ts
@@ -1732,6 +1732,9 @@ export namespace AMCP {
 	 */
 	export class ClsCommand extends AbstractCommand {
 		static readonly commandString = 'CLS'
+		paramProtocol = [
+			new ParamSignature(optional, 'subFolder', null, new ParameterValidator.ClipNameValidator())
+		]
 		responseProtocol = new ResponseSignature(200, ResponseValidator.ListValidator, ResponseParser.ContentParser)
 	}
 
@@ -1748,6 +1751,9 @@ export namespace AMCP {
 	 */
 	export class TlsCommand extends AbstractCommand {
 		static readonly commandString = 'TLS'
+		paramProtocol = [
+			new ParamSignature(optional, 'subFolder', null, new ParameterValidator.ClipNameValidator())
+		]
 		responseProtocol = new ResponseSignature(200, ResponseValidator.ListValidator, ResponseParser.ContentParser)
 	}
 


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Adding support for subFolders when calling CLS and TLS


* **What is the current behavior?** (You can also link to an open issue here)
Right now CLS and TLS will return all files in all folders


* **What is the new behavior (if this is a feature change)?**



* **Other information**:
