### PR TITLE
Add support for TLS responses in v2.2.0

### DIFF
--- a/src/lib/ResponseParsers.ts
+++ b/src/lib/ResponseParsers.ts
@@ -322,7 +322,11 @@ export namespace Response {
 				let components: RegExpMatchArray | null = i.match(/\"([\s\S]*)\" +([\s\S]*)/)
 
 				if (components === null) {
-					return null
+					// propably 2.2.0
+					return {
+						name: i,
+						type: 'template'
+					}
 				}
 
 				let name: string = components[1].replace(/\\/g, '/')


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Feature / support for CasparCG v2.2

* **What is the current behavior?** (You can also link to an open issue here)
Response from CasparCG server v2.2 of TLS command is not recognized (see issue #112).

* **What is the new behavior (if this is a feature change)?**
Plain lists without any additional fields are assumed to be responses from CasparCG v2.2 with just the name of the template.

* **Other information**
Tested with official CasparCG release "2018-12-29 - Version 2.2.0 Stable" and used in production at two multi day events during the last months with CasparCG as video playout server and generator for lower thirds.

