### PR TITLE
fix: cgAdd didn't serialize data properly

### DIFF
--- a/src/__tests__/serializers.spec.ts
+++ b/src/__tests__/serializers.spec.ts
@@ -1,5 +1,5 @@
 import { serializers, serializersV21 } from '../serializers'
-import { Commands, LoadbgDecklinkCommand, PlayCommand, PlayHtmlCommand } from '../commands'
+import { CgAddCommand, Commands, LoadbgDecklinkCommand, PlayCommand, PlayHtmlCommand } from '../commands'
 import { TransitionType } from '../enums'
 
 describe('serializers', () => {
@@ -112,5 +112,31 @@ describe('serializers', () => {
 		const result = serialized.filter((l) => l !== '').join(' ')
 
 		expect(result).toBe('PLAY 1-10 [html] http://example.com')
+	})
+
+	it('should serialize a cgAdd command with data', () => {
+		const command: CgAddCommand = {
+			command: Commands.CgAdd,
+			params: {
+				channel: 1,
+				layer: 10,
+				cgLayer: 1,
+				playOnLoad: true,
+				template: 'myFolder/myTemplate',
+				data: {
+					label: `These are difficult: "'&$\\/`,
+				},
+			},
+		}
+
+		const serialized = serializers[Commands.CgAdd].map((fn) => fn(command.command, command.params))
+
+		expect(serialized).toHaveLength(serializers[Commands.CgAdd].length)
+
+		const result = serialized.filter((l) => l !== '').join(' ')
+
+		expect(result).toBe(
+			`CG 1-10 ADD 1 "myFolder/myTemplate" 1 "{\\"label\\":\\"These are difficult: \\\\\\"'&\\$\\\\\\\\/\\"}"`
+		)
 	})
 })

--- a/src/serializers.ts
+++ b/src/serializers.ts
@@ -106,7 +106,10 @@ const cgDataSerializer = (_: Commands, { data }: CgUpdateParameters | CgAddParam
 	} else if (typeof data === 'string') {
 		return data
 	} else {
-		return JSON.stringify(data)
+		// Escape the data so that CasparCG can process it and send into templates:
+		// * Escape \, $ and "
+		// * Wrap in "-quotes
+		return `"${JSON.stringify(data).replace(/[\\$"]/g, '\\$&')}"`
 	}
 }
 
@@ -231,7 +234,7 @@ export const serializers: Readonly<Serializers<AMCPCommand>> = {
 		channelLayerSerializer,
 		splitCommandKeywordSerializer,
 		cgLayerSerializer,
-		(_, { template, playOnLoad }) => `${template} ${playOnLoad ? '1' : '0'}`,
+		(_, { template, playOnLoad }) => `"${template}" ${playOnLoad ? '1' : '0'}`,
 		cgDataSerializer,
 	],
 	[Commands.CgPlay]: [


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix


* **What is the current behavior?** (You can also link to an open issue here)
When calling
```javascript
caspar.cgAdd({
	channel: 1,
	layer: 10,
	cgLayer: 1,
	playOnLoad: true,
	template: 'myFolder/myHTMLTemplate',
	data: {
		label: `Hello!`,
	},
})
```
The command to caspar looks like this:
```
REQ ww2x7 CG 1-10 ADD 1 myFolder/myHTMLTemplate 1 {"label":"Hello!"}\r\n
```
The HTML template doesn't receive any data.

* **What is the new behavior (if this is a feature change)?**

The sent command is escaped and wrapped in quotes:
```
REQ m9sp3 CG 1-10 ADD 1 "myFolder/myHTMLTemplate" 1 "{\"label\":\"Hello!\"}"
```
The HTML template receives the data.

* **Other information**:

