### PR TITLE
fix: in cgAdd: make cgLayer be optional

### DIFF
--- a/src/__tests__/serializers.spec.ts
+++ b/src/__tests__/serializers.spec.ts
@@ -251,4 +251,46 @@ describe('serializers', () => {
 
 		expect(result).toBe(`MIXER 1-10 FILL 0.1 0.2 0.7 0.8 20`)
 	})
+	it('should serialize a cgAdd command with minimum params', () => {
+		const command: CgAddCommand = {
+			command: Commands.CgAdd,
+			params: {
+				channel: 1,
+				layer: 10,
+				template: 'myFolder/myTemplate',
+				playOnLoad: false,
+			},
+		}
+
+		const serialized = serializers[Commands.CgAdd].map((fn) => fn(command.command, command.params))
+
+		expect(serialized).toHaveLength(serializers[Commands.CgAdd].length)
+
+		const result = serialized.filter((l) => l !== '').join(' ')
+
+		expect(result).toBe(`CG 1-10 ADD 1 "myFolder/myTemplate" 0`)
+	})
+	it('should serialize a cgAdd command with all params defined', () => {
+		const command: CgAddCommand = {
+			command: Commands.CgAdd,
+			params: {
+				channel: 1,
+				layer: 10,
+				template: 'myFolder/myTemplate',
+				playOnLoad: true,
+				cgLayer: 2,
+				data: {
+					hello: 'world',
+				},
+			},
+		}
+
+		const serialized = serializers[Commands.CgAdd].map((fn) => fn(command.command, command.params))
+
+		expect(serialized).toHaveLength(serializers[Commands.CgAdd].length)
+
+		const result = serialized.filter((l) => l !== '').join(' ')
+
+		expect(result).toBe(`CG 1-10 ADD 2 "myFolder/myTemplate" 1 "{\\"hello\\":\\"world\\"}"`)
+	})
 })

--- a/src/parameters.ts
+++ b/src/parameters.ts
@@ -156,11 +156,13 @@ export interface DataRemoveParameters {
 }
 
 export interface CGLayer {
-	cgLayer: number
+	/** cgLayer (defaults to 1) */
+	cgLayer?: number
 }
 
 export interface CgAddParameters extends ChannelLayer, CGLayer {
 	template: string
+	/** If true, CasparCG will call play() in the template after load. */
 	playOnLoad: boolean
 	data?: Record<string, any> | string
 }

--- a/src/serializers.ts
+++ b/src/serializers.ts
@@ -95,7 +95,7 @@ const callAttributeSerializer = (_: Commands, { param, value }: CallParameters) 
 const consumerSerializer = (_: Commands, { consumer, parameters }: AddParameters) => consumer + ' ' + parameters
 const removeSerializer = (_: Commands, { consumer }: RemoveParameters) => consumer + ''
 
-const cgLayerSerializer = (_: Commands, { cgLayer }: CGLayer) => cgLayer + ''
+const cgLayerSerializer = (_: Commands, { cgLayer }: CGLayer) => (cgLayer === undefined ? '1' : `${cgLayer}`)
 const cgDataSerializer = (_: Commands, { data }: CgUpdateParameters | CgAddParameters) => {
 	if (!data) {
 		return ''


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
quality of life improvement


* **What is the current behavior?** (You can also link to an open issue here)

cgAdd requires the parameters `cgLayer` and `playOnLoad`

* **What is the new behavior (if this is a feature change)?**

`cgLayer` is optional and defaults to `1`

~`playOnLoad` is optional and defaults to `true`~


* **Other information**:

In my experience, `cgLayer` and `playOnLoad` are rarely used nowadays, so I think that we should allow for leaving them out and fill in the most-commonly used values.