### PR TITLE
fix: receiving fragmented message gets stuck SOFIE-2680

### DIFF
--- a/src/__mocks__/net.ts
+++ b/src/__mocks__/net.ts
@@ -1,0 +1,112 @@
+import { EventEmitter } from 'events'
+const sockets: Array<Socket> = []
+const onNextSocket: Array<(socket: Socket) => void> = []
+
+const orgSetImmediate = setImmediate
+
+export class Socket extends EventEmitter {
+	public onWrite?: (buff: Buffer, encoding: string) => void
+	public onConnect?: (port: number, host: string) => void
+	public onClose?: () => void
+
+	// private _port: number
+	// private _host: string
+	private _connected = false
+
+	public destroyed = false
+
+	constructor() {
+		super()
+
+		const cb = onNextSocket.shift()
+		if (cb) {
+			cb(this)
+		}
+
+		sockets.push(this)
+	}
+
+	public static mockSockets(): Socket[] {
+		return sockets
+	}
+	public static openSockets(): Socket[] {
+		return sockets.filter((s) => !s.destroyed)
+	}
+	public static mockOnNextSocket(cb: (s: Socket) => void): void {
+		onNextSocket.push(cb)
+	}
+	public static clearMockOnNextSocket(): void {
+		onNextSocket.splice(0, 99999)
+	}
+	// this.emit('connect')
+	// this.emit('close')
+	// this.emit('end')
+
+	public connect(port: number, host = 'localhost', cb?: () => void): void {
+		// this._port = port
+		// this._host = host
+
+		if (this.onConnect) this.onConnect(port, host)
+		orgSetImmediate(() => {
+			if (cb) {
+				cb()
+			}
+			this.setConnected()
+		})
+	}
+	public write(buf: Buffer, cb?: () => void): void
+	public write(buf: Buffer, encoding?: BufferEncoding, cb?: () => void): void
+	public write(buf: Buffer, encodingOrCb?: BufferEncoding | (() => void), cb?: () => void): void {
+		const DEFAULT_ENCODING = 'utf-8'
+		cb = typeof encodingOrCb === 'function' ? encodingOrCb : cb
+		const encoding = typeof encodingOrCb === 'function' ? DEFAULT_ENCODING : encodingOrCb
+		if (this.onWrite) {
+			this.onWrite(buf, encoding ?? DEFAULT_ENCODING)
+		}
+		if (cb) cb()
+	}
+	public end(): void {
+		this.setEnd()
+		this.setClosed()
+	}
+
+	public mockClose(): void {
+		this.setClosed()
+	}
+	public mockData(data: Buffer): void {
+		this.emit('data', data)
+	}
+
+	public setNoDelay(_noDelay?: boolean): void {
+		// noop
+	}
+
+	public setEncoding(_encoding?: BufferEncoding): void {
+		// noop
+	}
+
+	public destroy(): void {
+		this.destroyed = true
+	}
+
+	private setConnected() {
+		if (this._connected !== true) {
+			this._connected = true
+		}
+		this.emit('connect')
+	}
+	private setClosed() {
+		if (this._connected !== false) {
+			this._connected = false
+		}
+		this.destroyed = true
+		this.emit('close')
+		if (this.onClose) this.onClose()
+	}
+	private setEnd() {
+		if (this._connected !== false) {
+			this._connected = false
+		}
+		this.emit('end')
+	}
+}

--- a/src/__tests__/connection.spec.ts
+++ b/src/__tests__/connection.spec.ts
@@ -2,32 +2,195 @@ import { Version } from '../enums'
 import { Connection } from '../connection'
 import { serializersV21, serializers } from '../serializers'
 import { deserializers } from '../deserializers'
+import { Socket as OrgSocket } from 'net'
+import { Socket as MockSocket } from '../__mocks__/net'
+import { Commands } from '../commands'
+
+jest.mock('net')
+
+const SocketMock = OrgSocket as any as typeof MockSocket
 
 describe('connection', () => {
-	function setupConnectionClass(v = Version.v23x) {
-		const conn = new Connection('127.0.0.1', 5250, false)
-		conn.version = v
+	describe('version handing', () => {
+		function setupConnectionClass(v = Version.v23x) {
+			const conn = new Connection('127.0.0.1', 5250, false)
+			conn.version = v
 
-		return conn
-	}
-	it('should use 2.1 serializers for 2.1 connection', () => {
-		const conn = setupConnectionClass(Version.v21x)
+			return conn
+		}
+		it('should use 2.1 serializers for 2.1 connection', () => {
+			const conn = setupConnectionClass(Version.v21x)
 
-		expect(conn['_getVersionedSerializers']()).toBe(serializersV21)
+			expect(conn['_getVersionedSerializers']()).toBe(serializersV21)
+		})
+		it('should use 2.3 serializers for 2.3 connection', () => {
+			const conn = setupConnectionClass()
+
+			expect(conn['_getVersionedSerializers']()).toBe(serializers)
+		})
+		it('should use 2.1 deserializers for 2.1 connection', () => {
+			const conn = setupConnectionClass(Version.v21x)
+
+			expect(conn['_getVersionedDeserializers']()).toBe(deserializers)
+		})
+		it('should use 2.3 deserializers for 2.3 connection', () => {
+			const conn = setupConnectionClass()
+
+			expect(conn['_getVersionedDeserializers']()).toBe(deserializers)
+		})
 	})
-	it('should use 2.3 serializers for 2.3 connection', () => {
-		const conn = setupConnectionClass()
 
-		expect(conn['_getVersionedSerializers']()).toBe(serializers)
-	})
-	it('should use 2.1 deserializers for 2.1 connection', () => {
-		const conn = setupConnectionClass(Version.v21x)
+	describe('receiving', () => {
+		const onSocketCreate = jest.fn()
+		const onConnection = jest.fn()
+		const onSocketClose = jest.fn()
+		const onSocketWrite = jest.fn()
+		const onConnectionChanged = jest.fn()
 
-		expect(conn['_getVersionedDeserializers']()).toBe(deserializers)
-	})
-	it('should use 2.3 deserializers for 2.3 connection', () => {
-		const conn = setupConnectionClass()
+		function setupSocketMock() {
+			SocketMock.mockOnNextSocket((socket: any) => {
+				onSocketCreate()
 
-		expect(conn['_getVersionedDeserializers']()).toBe(deserializers)
+				socket.onConnect = onConnection
+				socket.onWrite = onSocketWrite
+				socket.onClose = onSocketClose
+			})
+		}
+		beforeEach(() => {
+			setupSocketMock()
+		})
+		afterEach(() => {
+			const sockets = SocketMock.openSockets()
+			// Destroy any lingering sockets, to prevent a failing test from affecting other tests:
+			sockets.forEach((s) => s.destroy())
+
+			SocketMock.clearMockOnNextSocket()
+			onSocketCreate.mockClear()
+			onConnection.mockClear()
+			onSocketClose.mockClear()
+			onSocketWrite.mockClear()
+			onConnectionChanged.mockClear()
+
+			// Just a check to ensure that the unit tests cleaned up the socket after themselves:
+			// eslint-disable-next-line jest/no-standalone-expect
+			expect(sockets).toHaveLength(0)
+		})
+
+		it('receive whole response', async () => {
+			const conn = new Connection('127.0.0.1', 5250, true)
+			try {
+				expect(conn).toBeTruthy()
+
+				const onConnError = jest.fn()
+				const onConnData = jest.fn()
+				conn.on('error', onConnError)
+				conn.on('data', onConnData)
+
+				const sockets = SocketMock.openSockets()
+				expect(sockets).toHaveLength(1)
+
+				// Dispatch a command
+				const sendError = await conn.sendCommand({
+					command: Commands.Info,
+					params: {},
+				})
+				expect(sendError).toBeFalsy()
+				expect(onConnError).toHaveBeenCalledTimes(0)
+				expect(onConnData).toHaveBeenCalledTimes(0)
+
+				// Info was sent
+				expect(onSocketWrite).toHaveBeenCalledTimes(1)
+				expect(onSocketWrite).toHaveBeenLastCalledWith('INFO\r\n', 'utf-8')
+
+				// Reply with a single blob
+				sockets[0].mockData(
+					Buffer.from(
+						`201 INFO OK\r\n<?xml version="1.0" encoding="utf-8"?>\n<channel><test/></channel>\r\n\r\n`
+					)
+				)
+
+				// Wait for deserializer to run
+				await new Promise(process.nextTick.bind(process))
+
+				expect(onConnError).toHaveBeenCalledTimes(0)
+				expect(onConnData).toHaveBeenCalledTimes(1)
+
+				// Check result looks good
+				expect(onConnData).toHaveBeenLastCalledWith({
+					command: 'INFO',
+					data: [
+						{
+							channel: {
+								test: [''],
+							},
+						},
+					],
+					message: 'The command has been executed and data is being returned.',
+					reqId: undefined,
+					responseCode: 201,
+					type: 'OK',
+				})
+			} finally {
+				// Ensure cleaned up
+				conn.disconnect()
+			}
+		})
+
+		it('receive fragmented response', async () => {
+			const conn = new Connection('127.0.0.1', 5250, true)
+			try {
+				expect(conn).toBeTruthy()
+
+				const onConnError = jest.fn()
+				const onConnData = jest.fn()
+				conn.on('error', onConnError)
+				conn.on('data', onConnData)
+
+				const sockets = SocketMock.openSockets()
+				expect(sockets).toHaveLength(1)
+
+				// Dispatch a command
+				const sendError = await conn.sendCommand({
+					command: Commands.Info,
+					params: {},
+				})
+				expect(sendError).toBeFalsy()
+				expect(onConnError).toHaveBeenCalledTimes(0)
+				expect(onConnData).toHaveBeenCalledTimes(0)
+
+				// Info was sent
+				expect(onSocketWrite).toHaveBeenCalledTimes(1)
+				expect(onSocketWrite).toHaveBeenLastCalledWith('INFO\r\n', 'utf-8')
+
+				// Reply with a fragmented message
+				sockets[0].mockData(Buffer.from(`201 INFO OK\r\n<?xml version="1.0" encoding="utf-8"?>\n<channel>`))
+				sockets[0].mockData(Buffer.from(`<test/></channel>\r\n\r\n`))
+
+				// Wait for deserializer to run
+				await new Promise(process.nextTick.bind(process))
+
+				expect(onConnError).toHaveBeenCalledTimes(0)
+				expect(onConnData).toHaveBeenCalledTimes(1)
+
+				// Check result looks good
+				expect(onConnData).toHaveBeenLastCalledWith({
+					command: 'INFO',
+					data: [
+						{
+							channel: {
+								test: [''],
+							},
+						},
+					],
+					message: 'The command has been executed and data is being returned.',
+					reqId: undefined,
+					responseCode: 201,
+					type: 'OK',
+				})
+			} finally {
+				// Ensure cleaned up
+				conn.disconnect()
+			}
+		})
 	})
 })

--- a/src/__tests__/connection.spec.ts
+++ b/src/__tests__/connection.spec.ts
@@ -125,20 +125,23 @@ describe('connection', () => {
 				expect(onConnData).toHaveBeenCalledTimes(1)
 
 				// Check result looks good
-				expect(onConnData).toHaveBeenLastCalledWith({
-					command: 'INFO',
-					data: [
-						{
-							channel: {
-								test: [''],
+				expect(onConnData).toHaveBeenLastCalledWith(
+					{
+						command: 'INFO',
+						data: [
+							{
+								channel: {
+									test: [''],
+								},
 							},
-						},
-					],
-					message: 'The command has been executed and data is being returned.',
-					reqId: undefined,
-					responseCode: 201,
-					type: 'OK',
-				})
+						],
+						message: 'The command has been executed and data is being returned.',
+						reqId: undefined,
+						responseCode: 201,
+						type: 'OK',
+					},
+					undefined
+				)
 			} finally {
 				// Ensure cleaned up
 				conn.disconnect()
@@ -182,20 +185,23 @@ describe('connection', () => {
 				expect(onConnData).toHaveBeenCalledTimes(1)
 
 				// Check result looks good
-				expect(onConnData).toHaveBeenLastCalledWith({
-					command: 'INFO',
-					data: [
-						{
-							channel: {
-								test: [''],
+				expect(onConnData).toHaveBeenLastCalledWith(
+					{
+						command: 'INFO',
+						data: [
+							{
+								channel: {
+									test: [''],
+								},
 							},
-						},
-					],
-					message: 'The command has been executed and data is being returned.',
-					reqId: undefined,
-					responseCode: 201,
-					type: 'OK',
-				})
+						],
+						message: 'The command has been executed and data is being returned.',
+						reqId: undefined,
+						responseCode: 201,
+						type: 'OK',
+					},
+					undefined
+				)
 			} finally {
 				// Ensure cleaned up
 				conn.disconnect()
@@ -258,28 +264,36 @@ describe('connection', () => {
 				expect(onConnData).toHaveBeenCalledTimes(2)
 
 				// Check result looks good
-				expect(onConnData).toHaveBeenNthCalledWith(1, {
-					command: 'PLAY',
-					data: [],
-					message: 'The command has been executed.',
-					reqId: 'cmd2',
-					responseCode: 202,
-					type: 'OK',
-				})
-				expect(onConnData).toHaveBeenNthCalledWith(2, {
-					command: 'INFO',
-					data: [
-						{
-							channel: {
-								test: [''],
+				expect(onConnData).toHaveBeenNthCalledWith(
+					1,
+					{
+						command: 'PLAY',
+						data: [],
+						message: 'The command has been executed.',
+						reqId: 'cmd2',
+						responseCode: 202,
+						type: 'OK',
+					},
+					undefined
+				)
+				expect(onConnData).toHaveBeenNthCalledWith(
+					2,
+					{
+						command: 'INFO',
+						data: [
+							{
+								channel: {
+									test: [''],
+								},
 							},
-						},
-					],
-					message: 'The command has been executed and data is being returned.',
-					reqId: 'cmd1',
-					responseCode: 201,
-					type: 'OK',
-				})
+						],
+						message: 'The command has been executed and data is being returned.',
+						reqId: 'cmd1',
+						responseCode: 201,
+						type: 'OK',
+					},
+					undefined
+				)
 			} finally {
 				// Ensure cleaned up
 				conn.disconnect()
@@ -334,15 +348,20 @@ describe('connection', () => {
 				expect(onConnError).toHaveBeenCalledTimes(0)
 				expect(onConnData).toHaveBeenCalledTimes(1)
 
-				// Check result looks good
-				expect(onConnData).toHaveBeenNthCalledWith(1, {
-					command: 'INFO',
-					data: ['<?xml'],
-					message: 'Invalid response received.',
-					reqId: 'cmd1',
-					responseCode: 500,
-					type: 'FAILED',
-				})
+				// Check result looks correct
+				expect(onConnData).toHaveBeenNthCalledWith(
+					1,
+					{
+						command: 'INFO',
+						data: ['<?xml'],
+						message: 'The command has been executed and data is being returned.',
+						reqId: 'cmd1',
+						responseCode: 201,
+						type: 'OK',
+					},
+					expect.any(Error)
+				)
+				expect(onConnData.mock.calls[0][1].toString()).toMatch(/Unexpected end/)
 				onConnData.mockClear()
 
 				// Reply with successful PLAY
@@ -353,14 +372,18 @@ describe('connection', () => {
 				expect(onConnData).toHaveBeenCalledTimes(1)
 
 				// Check result looks good
-				expect(onConnData).toHaveBeenNthCalledWith(1, {
-					command: 'PLAY',
-					data: [],
-					message: 'The command has been executed.',
-					reqId: 'cmd2',
-					responseCode: 202,
-					type: 'OK',
-				})
+				expect(onConnData).toHaveBeenNthCalledWith(
+					1,
+					{
+						command: 'PLAY',
+						data: [],
+						message: 'The command has been executed.',
+						reqId: 'cmd2',
+						responseCode: 202,
+						type: 'OK',
+					},
+					undefined
+				)
 			} finally {
 				// Ensure cleaned up
 				conn.disconnect()
@@ -421,19 +444,12 @@ describe('connection', () => {
 
 				expect(onConnError).toHaveBeenCalledTimes(0)
 				// expect(onConnData).toHaveBeenCalledTimes(1)
-				expect(onCommandOk).toHaveBeenCalledTimes(1)
-				expect(onCommandError).toHaveBeenCalledTimes(0)
+				expect(onCommandOk).toHaveBeenCalledTimes(0)
+				expect(onCommandError).toHaveBeenCalledTimes(1)
 
 				// Check result looks good
-				expect(onCommandOk).toHaveBeenNthCalledWith(1, {
-					command: 'INFO',
-					data: ['<?xml'],
-					message: 'Invalid response received.',
-					reqId: infoReqId,
-					responseCode: 500,
-					type: 'FAILED',
-				})
-				onCommandOk.mockClear()
+				expect(onCommandError.mock.calls[0][0].toString()).toMatch(/Unexpected end/)
+				onCommandError.mockClear()
 
 				// Reply with successful PLAY
 				const playReqId = extractReqId(2)
@@ -543,14 +559,18 @@ describe('connection', () => {
 				expect(onConnData).toHaveBeenCalledTimes(1)
 
 				// Check result looks good
-				expect(onConnData).toHaveBeenNthCalledWith(1, {
-					command: 'PLAY',
-					data: [],
-					message: 'The command has been executed.',
-					reqId: 'cmd2',
-					responseCode: 202,
-					type: 'OK',
-				})
+				expect(onConnData).toHaveBeenNthCalledWith(
+					1,
+					{
+						command: 'PLAY',
+						data: [],
+						message: 'The command has been executed.',
+						reqId: 'cmd2',
+						responseCode: 202,
+						type: 'OK',
+					},
+					undefined
+				)
 			} finally {
 				// Ensure cleaned up
 				conn.disconnect()

--- a/src/__tests__/connection.spec.ts
+++ b/src/__tests__/connection.spec.ts
@@ -259,6 +259,14 @@ describe('connection', () => {
 
 				// Check result looks good
 				expect(onConnData).toHaveBeenNthCalledWith(1, {
+					command: 'PLAY',
+					data: [],
+					message: 'The command has been executed.',
+					reqId: 'cmd2',
+					responseCode: 202,
+					type: 'OK',
+				})
+				expect(onConnData).toHaveBeenNthCalledWith(2, {
 					command: 'INFO',
 					data: [
 						{
@@ -270,14 +278,6 @@ describe('connection', () => {
 					message: 'The command has been executed and data is being returned.',
 					reqId: 'cmd1',
 					responseCode: 201,
-					type: 'OK',
-				})
-				expect(onConnData).toHaveBeenNthCalledWith(2, {
-					command: 'PLAY',
-					data: [],
-					message: 'The command has been executed.',
-					reqId: 'cmd2',
-					responseCode: 202,
 					type: 'OK',
 				})
 			} finally {

--- a/src/api.ts
+++ b/src/api.ts
@@ -87,11 +87,15 @@ export class BasicCasparCGAPI extends EventEmitter<ConnectionEvents> {
 		})
 		this._connection.on('disconnect', () => this.emit('disconnect'))
 
-		this._connection.on('data', (response) => {
+		this._connection.on('data', (response, error) => {
 			const request = this._requestQueue.find((req) => req.requestId === response.reqId)
 
 			if (request) {
-				request.resolve(response)
+				if (error) {
+					request.reject(error)
+				} else {
+					request.resolve(response)
+				}
 				this._requestQueue = this._requestQueue.filter((req) => req.requestId !== response.reqId)
 			}
 

--- a/src/api.ts
+++ b/src/api.ts
@@ -53,6 +53,12 @@ export type ConnectionEvents = {
 	error: [error: Error]
 }
 
+export class ResponseError extends Error {
+	constructor(public readonly deserializeError: Error, public readonly response: Response) {
+		super('Failed to deserialize response')
+	}
+}
+
 export class BasicCasparCGAPI extends EventEmitter<ConnectionEvents> {
 	private _connection: Connection
 	private _host: string
@@ -92,7 +98,7 @@ export class BasicCasparCGAPI extends EventEmitter<ConnectionEvents> {
 
 			if (request) {
 				if (error) {
-					request.reject(error)
+					request.reject(new ResponseError(error, response))
 				} else {
 					request.resolve(response)
 				}

--- a/src/api.ts
+++ b/src/api.ts
@@ -38,7 +38,7 @@ interface InternalRequest {
 }
 
 export interface Response {
-	reqId?: string
+	reqId: string | undefined
 	command: Commands
 	responseCode: number
 	data: any[]

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -231,12 +231,19 @@ export class Connection extends EventEmitter<ConnectionEvents> {
 		})
 		this._socket.on('connect', () => {
 			this._setConnected(true)
+
+			// Any data which hasn't been parsed yet is now incomplete, and can be discarded
+			this._discardUnprocessed()
 		})
 		this._socket.on('close', () => {
+			this._discardUnprocessed()
+
 			this._setConnected(false)
 			this._triggerReconnect()
 		})
 		this._socket.on('error', (e) => {
+			this._discardUnprocessed()
+
 			if (`${e}`.match(/ECONNREFUSED/)) {
 				// Unable to connect, no need to handle this error
 				this._setConnected(false)
@@ -246,6 +253,11 @@ export class Connection extends EventEmitter<ConnectionEvents> {
 		})
 
 		this._socket.connect(this.port, this.host)
+	}
+
+	private _discardUnprocessed() {
+		this._unprocessedData = ''
+		this._unprocessedLines = []
 	}
 
 	private _setConnected(connected: boolean) {

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -75,7 +75,7 @@ const RESPONSES = {
 }
 
 export type ConnectionEvents = {
-	data: [response: Response]
+	data: [response: Response, error: Error | undefined]
 	connect: []
 	disconnect: []
 	error: [error: Error]
@@ -192,15 +192,16 @@ export class Connection extends EventEmitter<ConnectionEvents> {
 				}
 
 				// now do something with response
-				this.emit('data', response)
+				this.emit('data', response, undefined)
 			})
-			.catch(() => {
-				this.emit('data', {
-					...response,
-					responseCode: 500, // TODO better value?
-					type: ResponseTypes.ServerError,
-					message: 'Invalid response received.',
-				})
+			.catch((e) => {
+				this.emit('data', response, e)
+				// {
+				// 	...response,
+				// 	responseCode: 500, // TODO better value?
+				// 	type: ResponseTypes.ServerError,
+				// 	message: 'Invalid response received.',
+				// })
 			})
 	}
 

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -155,11 +155,11 @@ export class Connection extends EventEmitter<ConnectionEvents> {
 
 				// parse additional lines if needed
 				if (response.responseCode === 200) {
-					const indexOfBlankLine = this._unprocessedLines.indexOf('')
-					if (indexOfBlankLine === -1) break // No termination yet, try again later
+					const indexOfTerminationLine = this._unprocessedLines.indexOf('')
+					if (indexOfTerminationLine === -1) break // No termination yet, try again later
 
 					// multiple lines of data
-					response.data = this._unprocessedLines.slice(1, indexOfBlankLine)
+					response.data = this._unprocessedLines.slice(1, indexOfTerminationLine)
 					processedLines += response.data.length + 1 // data lines + 1 empty line
 				} else if (response.responseCode === 201 || response.responseCode === 400) {
 					if (this._unprocessedLines.length < 2) break // No data line, try again later
@@ -176,7 +176,6 @@ export class Connection extends EventEmitter<ConnectionEvents> {
 			} else {
 				// well this is not happy, do we do something?
 				// perhaps this is the infamous 100 or 101 response code, although that doesn't appear in casparcg source code
-				// processedLines++
 				this._unprocessedLines.splice(0, 1)
 			}
 		}
@@ -196,12 +195,6 @@ export class Connection extends EventEmitter<ConnectionEvents> {
 			})
 			.catch((e) => {
 				this.emit('data', response, e)
-				// {
-				// 	...response,
-				// 	responseCode: 500, // TODO better value?
-				// 	type: ResponseTypes.ServerError,
-				// 	message: 'Invalid response received.',
-				// })
 			})
 	}
 


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

unit tests for a couple of bugs

* **What is the current behavior?** (You can also link to an open issue here)

The receiving logic is not very durable, and can be broken in a couple of ways:
1) A response gets broken over multiple TCP packets. Fragmentation like this is normal TCP behaviour, especially when using `INFO 1` on a channel with many active layers
2) When a deserializer fails, it crashes the parsing loop, and the connection gets stuck attempting to reparse the same message
3) There is a race condition in the parsing, if a second packet is received before a deserializer finishes, it will get parsed twice.

* **What is the new behavior?**

This fixes the known failures around fragmented or invalid responses.

There is a behavioural change here, previously an invalid response would result in a connection error and the command timing out. Now, an invalid response will resolve the command promise with a 500 error. 

`_unprocessedLines` and `_unprocessedData` is discarded upon the connection opening/closing, otherwise an incomplete fragment could cause the first response after reconnecting to get lost.

* **Other information**:
~~Also, it looks like `_unprocessedLines` is not cleared when the connection opens. I suspect this will result in TSR triggering a reconnection due to the timeout/error, but the same broken responses will be left in the queue, causing all future commands to also timeout until the device is restarted. I have not attempted to confirm this suspicion~~

I have tested this change with a script set to fire many commands at caspar, and is ensuring that it gets a successful response back.
Prior to this change running `INFO 2` would often time out, due to the reply being split across tcp packets. It is now successfully getting back `201` each time