### PR TITLE
fix: bug fix in INFO CHANNEL deserializer

### DIFF
--- a/src/__tests__/deserializers.spec.ts
+++ b/src/__tests__/deserializers.spec.ts
@@ -124,6 +124,38 @@ describe('deserializers', () => {
 			})
 		)
 	})
+	it('should deserialize INFO Channel (empty channel)', async () => {
+		const input = [
+			`<?xml version="1.0" encoding="utf-8"?>
+		<channel>
+		   <framerate>50</framerate>
+		   <framerate>1</framerate>
+		   <mixer>
+			  <audio>
+				 <volume>0</volume>
+				 <volume>0</volume>
+			  </audio>
+		   </mixer>
+		</channel>`,
+		]
+
+		const output = await deserializers[Commands.InfoChannel](input)
+
+		expect(output).toMatchObject(
+			literal<InfoChannelEntry>({
+				channel: {
+					framerate: 50,
+					mixer: {
+						audio: {
+							volumes: [0, 0],
+						},
+					},
+
+					layers: [],
+				},
+			})
+		)
+	})
 	it('should deserialize INFO Channel', async () => {
 		const input = [
 			`<?xml version="1.0" encoding="utf-8"?>

--- a/src/deserializers/deserializeInfoChannel.ts
+++ b/src/deserializers/deserializeInfoChannel.ts
@@ -12,6 +12,7 @@ export const deserializeInfoChannel = async (line: string): Promise<InfoChannelE
 	const channel = ensureArray(parsed.channel)[0]
 	const mixer = ensureArray(channel.mixer)[0]
 	const mixerStage = ensureArray(channel.stage)[0]
+	const mixerLayer = ensureArray(mixerStage?.layer)[0] ?? {}
 
 	const data: InfoChannelEntry = {
 		channel: {
@@ -23,7 +24,7 @@ export const deserializeInfoChannel = async (line: string): Promise<InfoChannelE
 			},
 
 			layers: compact(
-				Object.entries(ensureArray(mixerStage.layer)[0]).map(([layerName, layer0]) => {
+				Object.entries(mixerLayer).map(([layerName, layer0]) => {
 					const m = layerName.match(/layer_(\d+)/)
 					if (!m) return undefined
 


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix


* **What is the current behavior?** (You can also link to an open issue here)

Deserializer fails when the <stage> element was missing (when there is an empty channel)


* **What is the new behavior (if this is a feature change)?**

Deserializer returns `layers: []` as expected


* **Other information**:
