### PR TITLE
Functions for HTML-producers

### DIFF
--- a/src/CasparCG.ts
+++ b/src/CasparCG.ts
@@ -84,12 +84,20 @@ import {
 	CommitParameters,
 	DiscardParameters,
 	CustomCommandParameters,
+	PlayHtmlParameters,
+	LoadbgHtmlParameters,
 } from './parameters'
 
 export class CasparCG extends BasicCasparCGAPI {
 	async loadbg(params: LoadbgParameters): Promise<APIRequest<Commands.Loadbg>> {
 		return this.executeCommand({
 			command: Commands.Loadbg,
+			params,
+		})
+	}
+	async loadbgHtml(params: LoadbgHtmlParameters): Promise<APIRequest<Commands.LoadbgHtml>> {
+		return this.executeCommand({
+			command: Commands.LoadbgHtml,
 			params,
 		})
 	}
@@ -102,6 +110,12 @@ export class CasparCG extends BasicCasparCGAPI {
 	async play(params: PlayParameters): Promise<APIRequest<Commands.Play>> {
 		return this.executeCommand({
 			command: Commands.Play,
+			params,
+		})
+	}
+	async playHtml(params: PlayHtmlParameters): Promise<APIRequest<Commands.PlayHtml>> {
+		return this.executeCommand({
+			command: Commands.PlayHtml,
 			params,
 		})
 	}


### PR DESCRIPTION
* **What kind of change does this PR introduce?** feature

Commands to display websites (or Base64 encoded images). The interfaces and commands were already implemented - this PR adds the respective functions to the CasparCG-class

* **What is the current behavior?**

It's not possible to play websites.

* **Other information**

Tested with casparcg_v2.3.3_LTS and casparcg_v2.4.0