### PR TITLE
Feat!: PING

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,9 +66,12 @@ Installing with yarn adds the dev-dependencies needed to compile TypeScript. A s
 
 ## Doing a release
 
-- Run `yarn changelog` to generate the changelog, tags and commit.
-- Push these changes and the newly made tag.
-- Trigger a run of the [Publish to NPM](https://github.com/SuperFlyTV/casparcg-connection/actions/workflows/publish.yaml) workflow in GitHub Actions.
+- Run `yarn changelog` to generate the changelog, tags and commit. Push to Github.
+- A Github Action will automatically build and publish to npm.
+
+### Prerelease / nightly
+
+You can manually trigger publishing a nightly built at https://github.com/SuperFlyTV/casparcg-connection/actions/workflows/publish.yaml
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ In your code, include and use the CasparCG object from this library with a code 
 ```javascript
 const { CasparCG } = require('casparcg-connection')
 
-const connection = new CasparCG()
+const connection = new CasparCG({ host: 'localhost', port: 5250 })
 const { error, request } = await connection.play({ channel: 1, layer: 1, clip: 'amb' })
 if (error) {
 	console.log('Error when sending', error)
@@ -62,14 +62,13 @@ Installing with yarn adds the dev-dependencies needed to compile TypeScript. A s
 - **`yarn build`** Runs a single build command without watching for changes.
 - **`yarn build -w`** Rebuilds on every change.
 - **`yarn lint`** Runs code linting. Pull Requests won't be accepted without lint compliance.
-- **`yarn test`** Runs code tests through Jest.
+- **`yarn test`** Runs code tests through vitest.
 
 ## Doing a release
 
-* Run `yarn changelog` to generate the changelog, tags and commit.
-* Push these changes and the newly made tag.
-* Trigger a run of the [Publish to NPM](https://github.com/SuperFlyTV/casparcg-connection/actions/workflows/publish.yaml) workflow in GitHub Actions.
-
+- Run `yarn changelog` to generate the changelog, tags and commit.
+- Push these changes and the newly made tag.
+- Trigger a run of the [Publish to NPM](https://github.com/SuperFlyTV/casparcg-connection/actions/workflows/publish.yaml) workflow in GitHub Actions.
 
 ## Documentation
 

--- a/src/CasparCG.ts
+++ b/src/CasparCG.ts
@@ -79,7 +79,6 @@ import {
 	RestartParameters,
 	InfoChannelParameters,
 	InfoLayerParameters,
-	PingParameters,
 	BeginParameters,
 	CommitParameters,
 	DiscardParameters,
@@ -570,12 +569,6 @@ export class CasparCG extends BasicCasparCGAPI {
 	async restart(params: RestartParameters = {}): Promise<APIRequest<Commands.Restart>> {
 		return this.executeCommand({
 			command: Commands.Restart,
-			params,
-		})
-	}
-	async ping(params: PingParameters = {}): Promise<APIRequest<Commands.Ping>> {
-		return this.executeCommand({
-			command: Commands.Ping,
 			params,
 		})
 	}

--- a/src/__mocks__/net.ts
+++ b/src/__mocks__/net.ts
@@ -85,6 +85,9 @@ export class Socket extends EventEmitter {
 		// noop
 	}
 
+	public setKeepAlive(): void {
+		// noop
+	}
 	public destroy(): void {
 		this.destroyed = true
 	}

--- a/src/__tests__/connection.spec.ts
+++ b/src/__tests__/connection.spec.ts
@@ -21,7 +21,7 @@ const PARSED_INFO_CHANNEL_720p50 = {
 describe('connection', () => {
 	describe('version handing', () => {
 		function setupConnectionClass(v = Version.v23x) {
-			const conn = new Connection('127.0.0.1', 5250, false, () => undefined)
+			const conn = new Connection('127.0.0.1', 5250, false, 0, () => undefined)
 			conn.version = v
 
 			return conn
@@ -102,7 +102,7 @@ describe('connection', () => {
 			) => Promise<void>
 		) {
 			const getRequestForResponse = vi.fn()
-			const conn = new Connection('127.0.0.1', 5250, true, getRequestForResponse)
+			const conn = new Connection('127.0.0.1', 5250, true, 0, getRequestForResponse)
 			try {
 				expect(conn).toBeTruthy()
 
@@ -528,4 +528,239 @@ describe('connection', () => {
 			})
 		})
 	})
+	describe('connection management', () => {
+		let enablePingReplies = true
+		const PING_INTERVAL = 10 // [ms] Something short to make the test run fast, but not too short to cause flakiness
+		const RECONNECT_TIME = PING_INTERVAL * 3 // something short, but distinctly longer than the ping interval
+
+		const onSocketCreate = vi.fn()
+		const onConnection = vi.fn()
+		const onSocketClose = vi.fn()
+		const onSocketWrite = vi.fn((data) => {
+			if (data === 'PING\r\n') {
+				// Reply to ping
+				const sockets = SocketMock.openSockets()
+				if (sockets.length !== 1) throw new Error(`Expected 1 socket, got ${sockets.length}`)
+				const socket = sockets[0]
+
+				if (enablePingReplies) socket.mockData(Buffer.from(`PONG\r\n\r\n`)) // reply to PING
+			}
+		})
+		const onConnectionChanged = vi.fn()
+		const getRequestForResponse = vi.fn(() => {
+			return undefined
+		})
+		function getPingCount() {
+			return onSocketWrite.mock.calls.filter((call) => call[0] === 'PING\r\n').length
+		}
+
+		beforeEach(() => {
+			for (let i = 0; i < 2; i++) {
+				SocketMock.mockOnNextSocket((socket: any) => {
+					onSocketCreate()
+
+					socket.onConnect = onConnection
+					socket.onWrite = onSocketWrite
+					socket.onClose = onSocketClose
+				})
+			}
+		})
+		afterEach(() => {
+			const sockets = SocketMock.openSockets()
+			// Destroy any lingering sockets, to prevent a failing test from affecting other tests:
+			sockets.forEach((s) => s.destroy())
+
+			SocketMock.clearMockOnNextSocket()
+			onSocketCreate.mockClear()
+			onConnection.mockClear()
+			onSocketClose.mockClear()
+			onSocketWrite.mockClear()
+			onConnectionChanged.mockClear()
+
+			// Just a check to ensure that the unit tests cleaned up the socket after themselves:
+			if (sockets.length !== 0) throw new Error(`Expected 0 sockets, got ${sockets.length}`)
+		})
+		it('reconnects after socket close', async () => {
+			const conn = new Connection('127.0.0.1', 5250, true, 0, getRequestForResponse, RECONNECT_TIME)
+			try {
+				expect(conn).toBeTruthy()
+
+				const onConnError = vi.fn()
+				const onConnConnect = vi.fn()
+				const onConnDisconnect = vi.fn()
+				conn.on('error', onConnError)
+				conn.on('connect', onConnConnect)
+				conn.on('disconnect', onConnDisconnect)
+
+				expect(onSocketCreate).toHaveBeenCalledTimes(1)
+				onSocketCreate.mockClear()
+
+				const sockets = SocketMock.openSockets()
+				expect(sockets).toHaveLength(1)
+				const socket = sockets[0]
+
+				// Wait for connection to be established:
+				await new Promise<void>((resolve, reject) => {
+					conn.once('connect', () => resolve())
+					setTimeout(() => reject(new Error('Connection timeout in test')), 1000)
+				})
+
+				expect(conn.connected).toBeTruthy()
+				expect(onConnConnect).toHaveBeenCalledTimes(1)
+				onConnConnect.mockClear()
+				expect(onConnDisconnect).toHaveBeenCalledTimes(0)
+				onConnDisconnect.mockClear()
+				expect(onSocketCreate).toHaveBeenCalledTimes(0)
+
+				// Close socket and wait for 'disconnect' event to be emitted:
+				await new Promise<void>((resolve, reject) => {
+					conn.once('disconnect', () => resolve())
+					setTimeout(() => reject(new Error('Disconnection timeout in test')), 1000)
+					// Close socket:
+					socket.mockClose()
+				})
+
+				expect(conn.connected).toBeFalsy()
+				expect(onConnConnect).toHaveBeenCalledTimes(0)
+				expect(onConnDisconnect).toHaveBeenCalledTimes(1)
+				expect(onSocketCreate).toHaveBeenCalledTimes(0)
+				onConnConnect.mockClear()
+				onConnDisconnect.mockClear()
+				onSocketCreate.mockClear()
+
+				// Now, a reconnect should be attempted by the Connection:
+
+				await waitFor(() => {
+					expect(onSocketCreate).toHaveBeenCalledTimes(1)
+					expect(onConnConnect).toHaveBeenCalledTimes(1)
+				}, RECONNECT_TIME * 2.5)
+				onSocketCreate.mockClear()
+				onConnConnect.mockClear()
+
+				expect(onConnDisconnect).toHaveBeenCalledTimes(0)
+				onConnDisconnect.mockClear()
+
+				// Last:
+				expect(onConnError).toHaveBeenCalledTimes(0)
+			} finally {
+				// Ensure cleaned up
+				conn.disconnect()
+			}
+		})
+		it('reconnects after PING loss', async () => {
+			const conn = new Connection('127.0.0.1', 5250, true, PING_INTERVAL, getRequestForResponse, RECONNECT_TIME)
+			try {
+				expect(conn).toBeTruthy()
+
+				const onConnError = vi.fn()
+				const onConnConnect = vi.fn()
+				const onConnDisconnect = vi.fn()
+				conn.on('error', onConnError)
+				conn.on('connect', onConnConnect)
+				conn.on('disconnect', onConnDisconnect)
+
+				expect(onSocketCreate).toHaveBeenCalledTimes(1)
+				onSocketCreate.mockClear()
+
+				const sockets = SocketMock.openSockets()
+				expect(sockets).toHaveLength(1)
+
+				// Wait for connection to be established:
+				await new Promise<void>((resolve, reject) => {
+					conn.once('connect', () => resolve())
+					setTimeout(() => reject(new Error('Connection timeout in test')), 1000)
+				})
+
+				// PING should have been sent by now:
+				expect(getPingCount()).toBeGreaterThanOrEqual(1)
+				onSocketWrite.mockClear()
+
+				expect(conn.connected).toBeTruthy()
+				expect(onConnConnect).toHaveBeenCalledTimes(1)
+				onConnConnect.mockClear()
+				expect(onConnDisconnect).toHaveBeenCalledTimes(0)
+				onConnDisconnect.mockClear()
+				expect(onSocketCreate).toHaveBeenCalledTimes(0)
+
+				// Ensure that more PINGs are sent:
+				await waitFor(() => {
+					expect(getPingCount()).toBeGreaterThanOrEqual(2)
+				}, PING_INTERVAL * 3)
+
+				onSocketWrite.mockClear()
+
+				// Now, stop replying to PINGs:
+				enablePingReplies = false
+
+				// Wait for disconnect to be emitted, which should happen after a PING is sent and not replied to:
+				await new Promise<void>((resolve, reject) => {
+					conn.once('disconnect', () => resolve())
+					setTimeout(() => reject(new Error('Disconnection timeout in test')), 1000)
+				})
+
+				expect(getPingCount()).toBeGreaterThanOrEqual(1) // Ensure PING's has been sent
+
+				expect(conn.connected).toBeFalsy()
+				expect(onConnConnect).toHaveBeenCalledTimes(0)
+				expect(onConnDisconnect).toHaveBeenCalledTimes(1)
+				expect(onSocketCreate).toHaveBeenCalledTimes(0)
+				onConnConnect.mockClear()
+				onConnDisconnect.mockClear()
+				onSocketCreate.mockClear()
+
+				// Now, a reconnect should be attempted by the Connection:
+
+				await waitFor(() => {
+					expect(onSocketCreate).toHaveBeenCalledTimes(1)
+				}, RECONNECT_TIME * 2.5)
+
+				onSocketCreate.mockClear()
+
+				// Allow PING replies again, so that the reconnect can succeed:
+				enablePingReplies = true
+
+				// Wait for the new connection to be established:
+				await new Promise<void>((resolve, reject) => {
+					conn.once('connect', () => resolve())
+					setTimeout(() => reject(new Error('Connection timeout in test')), 1000)
+				})
+
+				expect(onConnConnect).toHaveBeenCalledTimes(1)
+				expect(onConnDisconnect).toHaveBeenCalledTimes(0)
+				onConnConnect.mockClear()
+				onConnDisconnect.mockClear()
+
+				// Last:
+				expect(onConnError).toHaveBeenCalledTimes(0)
+			} finally {
+				// Ensure cleaned up
+				conn.disconnect()
+			}
+		})
+	})
 })
+
+/** Wait for a condition to be fulfilled, ie the callback to not throw anymore. */
+async function waitFor(cb: () => void, timeout = 1000, testInterval?: number): Promise<void> {
+	if (timeout <= 0) throw new Error('Timeout must be greater than 0')
+
+	if (testInterval === undefined) testInterval = Math.max(1, Math.floor(timeout / 10))
+
+	const startTime = Date.now()
+	let lastError: any = undefined
+	do {
+		try {
+			cb()
+			return
+		} catch (err) {
+			lastError = err
+			// Wait a bit and try again:
+			await new Promise((resolve) => setTimeout(resolve, testInterval))
+		}
+	} while (Date.now() - startTime < timeout)
+
+	console.error(`waitFor timed out after ${Date.now() - startTime}ms (limit: ${timeout}).`)
+
+	if (lastError) throw lastError
+	else throw new Error('waitFor timed out without throwing an error')
+}

--- a/src/api.ts
+++ b/src/api.ts
@@ -11,6 +11,10 @@ export interface Options {
 	timeoutTime?: number
 	/** Immediately connects after instantiating the class, defaults to false */
 	autoConnect?: boolean
+	/** Interval to send PING:s to CasparCG (milliseconds) . Set to 0 to disable. Defaults to 30000 */
+	pingInterval?: number
+	/** Time until a reconnection is attempted (milliseconds). Defaults to 5000 */
+	reconnectTime?: number
 }
 
 export type SendResult<ReturnData> =
@@ -80,12 +84,14 @@ export class BasicCasparCGAPI extends EventEmitter<ConnectionEvents> {
 			this._host,
 			this._port,
 			!(options?.autoConnect === false),
+			options?.pingInterval ?? 30000,
 			(response: Response<any>) => {
 				// Connection asks: "what request does this response belong to?"
 				const request = this.findRequestFromResponse(response)
 				if (request) return { command: request.command }
 				else return undefined
-			}
+			},
+			options?.reconnectTime
 		)
 
 		this._connection.on('connect', () => {

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -91,7 +91,6 @@ import {
 	InfoConfig,
 	BeginParameters,
 	CommitParameters,
-	PingParameters,
 	DiscardParameters,
 	CustomCommandParameters,
 } from './parameters.js'
@@ -181,7 +180,6 @@ export enum Commands {
 	Bye = 'BYE',
 	Kill = 'KILL',
 	Restart = 'RESTART',
-	Ping = 'PING',
 	Begin = 'BEGIN',
 	Commit = 'COMMIT',
 	Discard = 'DISCARD',
@@ -300,7 +298,6 @@ export interface AllTypedCommands {
 	[Commands.Bye]: TypedResponseCommand<Commands.Bye, ByeParameters, unknown>
 	[Commands.Kill]: TypedResponseCommand<Commands.Kill, KillParameters, unknown>
 	[Commands.Restart]: TypedResponseCommand<Commands.Restart, RestartParameters, unknown>
-	[Commands.Ping]: TypedResponseCommand<Commands.Ping, PingParameters, unknown>
 	[Commands.Begin]: TypedResponseCommand<Commands.Begin, BeginParameters, unknown>
 	[Commands.Commit]: TypedResponseCommand<Commands.Commit, CommitParameters, unknown>
 	[Commands.Discard]: TypedResponseCommand<Commands.Discard, DiscardParameters, unknown>
@@ -392,7 +389,6 @@ export type GlGcCommand = AllTypedCommands[Commands.GlGc]['command']
 export type ByeCommand = AllTypedCommands[Commands.Bye]['command']
 export type KillCommand = AllTypedCommands[Commands.Kill]['command']
 export type RestartCommand = AllTypedCommands[Commands.Restart]['command']
-export type PingCommand = AllTypedCommands[Commands.Ping]['command']
 export type BeginCommand = AllTypedCommands[Commands.Begin]['command']
 export type CommitCommand = AllTypedCommands[Commands.Commit]['command']
 export type DiscardCommand = AllTypedCommands[Commands.Discard]['command']
@@ -483,7 +479,6 @@ export type AMCPCommand =
 	| ByeCommand
 	| KillCommand
 	| RestartCommand
-	| PingCommand
 	| BeginCommand
 	| CommitCommand
 	| DiscardCommand

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -89,21 +89,51 @@ export class Connection extends EventEmitter<ConnectionEvents> {
 	private _unprocessedData = ''
 	private _unprocessedLines: string[] = []
 	private _reconnectTimeout?: NodeJS.Timeout
-	private _connected = false
+	private _socketConnected = false
+	private _emittedConnected = false
 	private _version = Version.v23x
+
+	private _pingTimeout?: NodeJS.Timeout
+	/**
+	 * Timestamp when last PING (in reply to PING) was received.
+	 * Is set to -1 before first PING is sent
+	 */
+	private _lastPongReceivedTime: number = -1
+
+	/** Whether the Connection should be reconnecting or not */
+	private _shouldBeConnected = false
 
 	constructor(
 		private host: string,
 		private port = 5250,
+		/** Set to true to initialize connection. (If set to false, changeConnection() must be called to connect later.) */
 		autoConnect: boolean,
-		private _getRequestForResponse: (response: Response<any>) => SentRequest | undefined
+		/** Set to 0 to disable */
+		private pingInterval: number,
+		private _getRequestForResponse: (response: Response<any>) => SentRequest | undefined,
+		/** Time until a reconnection is attempted[ms] */
+		private reconnectTime = 5000
 	) {
 		super()
-		if (autoConnect) this._setupSocket()
+		if (autoConnect) this.changeConnection(host, port)
 	}
 
 	get connected(): boolean {
-		return this._connected
+		if (!this._socketConnected) return false
+		if (
+			// Pinging is enabled:
+			this.pingInterval > 0
+		) {
+			// If we haven't sent first PING yet, we consider the connection to be disconnected,
+			// otherwise connection status will flicker on -> off -> on upon startup:
+			if (this._lastPongReceivedTime === -1) return false
+
+			// Ping connectivity is NOT established,
+			// ie a PONG has not been received within 2x the ping interval, which is a reasonable time to expect a reply:
+
+			if (Date.now() - this._lastPongReceivedTime > this.pingInterval * 2) return false
+		}
+		return true
 	}
 
 	set version(version: Version) {
@@ -116,11 +146,16 @@ export class Connection extends EventEmitter<ConnectionEvents> {
 
 		this._socket?.end()
 
+		this._shouldBeConnected = true
 		this._setupSocket()
 	}
 
 	disconnect(): void {
+		this._shouldBeConnected = false
+
 		this._socket?.end()
+		clearInterval(this._pingTimeout)
+		this._pingTimeout = undefined
 	}
 
 	async sendCommand(cmd: AMCPCommand, reqId?: string): Promise<Error | undefined> {
@@ -146,7 +181,20 @@ export class Connection extends EventEmitter<ConnectionEvents> {
 		this._unprocessedLines.push(...newLines)
 
 		while (this._unprocessedLines.length > 0) {
-			const result = RESPONSE_REGEX.exec(this._unprocessedLines[0])
+			const line = this._unprocessedLines[0]
+
+			// Special case: "PONG" reply:
+			if (line === 'PONG') {
+				// Note: "PONG" doesn't follow the usual response format,
+				// and is sent by CasparCG in response to a PING command.
+
+				this._lastPongReceivedTime = Date.now()
+				this._handleChangedConnectionStatus()
+				// remove processed lines
+				this._unprocessedLines.splice(0, 1)
+				continue
+			}
+			const result = RESPONSE_REGEX.exec(line)
 
 			if (result?.groups?.['ResponseCode']) {
 				let processedLines = 1
@@ -217,16 +265,6 @@ export class Connection extends EventEmitter<ConnectionEvents> {
 			})
 	}
 
-	private _triggerReconnect() {
-		if (!this._reconnectTimeout) {
-			this._reconnectTimeout = setTimeout(() => {
-				this._reconnectTimeout = undefined
-
-				if (!this._connected) this._setupSocket()
-			}, 5000)
-		}
-	}
-
 	private _setupSocket() {
 		if (this._socket) {
 			this._socket.removeAllListeners()
@@ -237,6 +275,7 @@ export class Connection extends EventEmitter<ConnectionEvents> {
 
 		this._socket = new Socket()
 		this._socket.setEncoding('utf-8')
+		this._socket.setKeepAlive(true)
 
 		this._socket.on('data', (data) => {
 			try {
@@ -246,26 +285,37 @@ export class Connection extends EventEmitter<ConnectionEvents> {
 			}
 		})
 		this._socket.on('connect', () => {
-			this._setConnected(true)
+			this._socketConnected = true
+			this._handleChangedConnectionStatus()
 
 			// Any data which hasn't been parsed yet is now incomplete, and can be discarded
 			this._discardUnprocessed()
+
+			this.setupPing()
 		})
 		this._socket.on('close', () => {
 			this._discardUnprocessed()
 
-			this._setConnected(false)
-			this._triggerReconnect()
+			this._socketConnected = false
+			this._handleChangedConnectionStatus()
 		})
 		this._socket.on('error', (e) => {
 			this._discardUnprocessed()
 
-			if (`${e}`.match(/ECONNREFUSED/)) {
-				// Unable to connect, no need to handle this error
-				this._setConnected(false)
-			} else {
-				this.emit('error', e)
+			const errorString =
+				// Simple Error:
+				`${e}` +
+					// Error object with code property (such as AggregateError):
+					(e instanceof Error && (e as any).code) || ''
+
+			if (errorString.match(/ECONNREFUSED/) || errorString.match(/ECONNRESET/)) {
+				// Unable to connect, handle this as a disconnect event:
+				this._socketConnected = false
+				this._handleChangedConnectionStatus()
+				return
 			}
+
+			this.emit('error', e)
 		})
 
 		this._socket.connect(this.port, this.host)
@@ -276,17 +326,32 @@ export class Connection extends EventEmitter<ConnectionEvents> {
 		this._unprocessedLines = []
 	}
 
-	private _setConnected(connected: boolean) {
-		if (connected) {
-			if (!this._connected) {
-				this._connected = true
-				this.emit('connect')
+	private _handleChangedConnectionStatus() {
+		const actuallyConnected = this.connected
+
+		// If the status has changed, emit the appropriate event:
+		if (actuallyConnected !== this._emittedConnected) {
+			this._emittedConnected = actuallyConnected
+			if (actuallyConnected) this.emit('connect')
+			else this.emit('disconnect')
+		}
+
+		// Handle reconnection logic:
+		if (actuallyConnected) {
+			// Is connected, so cancel any pending reconnections:
+			if (this._reconnectTimeout) {
+				clearTimeout(this._reconnectTimeout)
+				this._reconnectTimeout = undefined
 			}
-		} else {
-			if (this._connected) {
-				this._connected = false
-				this.emit('disconnect')
-			}
+		} else if (this._shouldBeConnected && !this._reconnectTimeout) {
+			// Is disconnected, so schedule a reconnect if not already scheduled
+			this._reconnectTimeout = setTimeout(() => {
+				this._reconnectTimeout = undefined
+				if (!this._shouldBeConnected) return
+
+				// Check if we're already connected, in which case we don't need to reconnect:
+				if (!this.connected) this._setupSocket()
+			}, this.reconnectTime)
 		}
 	}
 
@@ -320,5 +385,36 @@ export class Connection extends EventEmitter<ConnectionEvents> {
 		[key: string]: (input: string[]) => Promise<any>
 	} {
 		return deserializers
+	}
+	private setupPing() {
+		if (this._pingTimeout !== undefined) {
+			clearInterval(this._pingTimeout)
+			this._pingTimeout = undefined
+		}
+
+		if (this.pingInterval > 0) {
+			const sendPing = () => {
+				if (!this._socketConnected) {
+					// Socket not connected, setupPing() will be called when the socket connects, so we can just return here.
+					this._lastPongReceivedTime = -1 // reset
+					return
+				}
+				// Trigger _maybeEmitConnectionEvent() to update connection status based on last pong received time:
+				this._handleChangedConnectionStatus()
+
+				if (this._lastPongReceivedTime === -1) this._lastPongReceivedTime = 0 // Signal that first ping has been sent
+
+				// Send PING command:
+				// Note: We're bypassing the normal sendCommand function here,
+				// because in CasparCG the PING command is parsed and handled before the normal command queue,
+				// therefore it doesn't support the usual REQ/RES-wrapping.
+				this._socket?.write('PING' + '\r\n', (e) => {
+					if (e) this.emit('error', e)
+				})
+			}
+
+			this._pingTimeout = setInterval(sendPing, this.pingInterval)
+			sendPing()
+		}
 	}
 }

--- a/src/parameters.ts
+++ b/src/parameters.ts
@@ -542,7 +542,6 @@ export type GlGcParameters = Empty
 export type ByeParameters = Empty
 export type KillParameters = Empty
 export type RestartParameters = Empty
-export type PingParameters = Empty
 export type BeginParameters = Empty
 export type CommitParameters = Empty
 export type DiscardParameters = Empty

--- a/src/serializers.ts
+++ b/src/serializers.ts
@@ -532,7 +532,6 @@ export const serializers: Readonly<Serializers<AMCPCommand>> = {
 	[Commands.Bye]: [commandNameSerializer],
 	[Commands.Kill]: [commandNameSerializer],
 	[Commands.Restart]: [commandNameSerializer],
-	[Commands.Ping]: [commandNameSerializer],
 	[Commands.Begin]: [commandNameSerializer],
 	[Commands.Commit]: [commandNameSerializer],
 	[Commands.Discard]: [commandNameSerializer],


### PR DESCRIPTION
**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

feature

**What is the current behavior?** (You can also link to an open issue here)

If a socket is open for a prolonged time with no data being sent over it, some firewalls may decide that the socket is dead and just drops it. This might not be detected by the original party as a closed socket, instead any data is sent on the socket just gets lost in.

**What is the new behavior (if this is a feature change)?**

* BREAKING CHANGE: feat!: remove PingCommand
  The PING command doesn't follow the usual REQ/RES format in CasparCG, so it has never really worked.
  (Even though technically, if sending a command `REQ h3l3x PING`, CasparCG will reply with `RES h3l3x 400 ERROR\r\nREQ h3l3x PING\r\n`, which can technically be interpreted as a "PONG"-ok.)

* feat: add pingInterval option, defaults to 30 seconds. casparcg-connection will now send PING commands to CasparCG, to ensure connectivity.
  Reason for adding this is to avoid the socket being dropped by a firewall, due to no data being sent on the socket over a longer time period.


**Other information**:
